### PR TITLE
Solaris and non posix shell compatibility

### DIFF
--- a/lib/release.ex
+++ b/lib/release.ex
@@ -278,7 +278,7 @@ defmodule Relex.Release do
     #! /bin/sh
     readlink_f () {
       cd "$(dirname "$1")" > /dev/null
-      local filename="$(basename "$1")"
+      filename="$(basename "$1")"
       if [ -h "$filename" ]; then
         readlink_f "$(readlink "$filename")"
       else


### PR DESCRIPTION
Removing local scope in erl runner script. Solaris and derivatives don't understand the "local" keyword in the "sh" shell. In this case, removing the local scope doesn't make any difference to the execution of the script. 

With this minor change, the release works fine on solaris machines.

Thanks and great work on this project! 
