### PR TITLE
`Keyword.from_enum/1` is deprecated. Replace with `Enum.to_list/1`

### DIFF
--- a/lib/app.ex
+++ b/lib/app.ex
@@ -91,7 +91,7 @@ defrecord Relex.App, name: nil, version: nil, path: nil, app: nil, type: :perman
 
   defp keys(rec) do
     {:application, _, opts} = app(rec)
-    Keyword.from_enum(opts)
+    Enum.to_list(opts)
   end
 
 end


### PR DESCRIPTION
Running relex on Elixir 0.13.1 fails, as `Keyword.from_enum/1` has been removed.

In Elixir 0.13.0, the correct replacement is `Enum/into/2`, but this isn't available in earlier versions, and would break users on ~ 0.12

Under the hood, `Keyword.from_enum/1` used to just call `Enum.to_list/1`, so this preserves the behaviour. This works on ~> 0.13.0 and ~> 0.12.4
